### PR TITLE
Fix `extern crate` value in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This crate implements some stemmer algorithms found in the [snowball project](ht
 # Usage
 
 ```rust
-extern crate native_stemmers;
+extern crate rust_stemmers;
 use rust_stemmers::{Algorithm, Stemmer};
 
 // Create a stemmer for the english language


### PR DESCRIPTION
The example in the readme doesn't seem to be referencing the correct crate. This fixes it.